### PR TITLE
Improving adds and subtractions

### DIFF
--- a/rust-escrow/conditional-escrow/src/lib.rs
+++ b/rust-escrow/conditional-escrow/src/lib.rs
@@ -390,7 +390,7 @@ mod tests {
         assert_eq!(
             false,
             contract.is_withdrawal_allowed(),
-            "Withdrawal should be allowed"
+            "Withdrawal should not be allowed"
         );
 
         contract.delegate_funds();
@@ -419,7 +419,7 @@ mod tests {
         assert_eq!(
             false,
             contract.is_deposit_allowed(),
-            "Deposit should be allowed"
+            "Deposit should not be allowed"
         );
 
         assert_eq!(

--- a/rust-escrow/conditional-escrow/src/lib.rs
+++ b/rust-escrow/conditional-escrow/src/lib.rs
@@ -107,10 +107,10 @@ impl ConditionalEscrow {
         let amount = env::attached_deposit();
         let payee = env::signer_account_id();
         let current_balance = self.deposits_of(&payee);
-        let new_balance = &(&current_balance + &amount);
+        let new_balance = &(current_balance.wrapping_add(amount));
 
         self.deposits.insert(&payee, new_balance);
-        self.total_funds += amount;
+        self.total_funds = self.total_funds.wrapping_add(amount);
 
         log!(
             "{} deposited {} NEAR tokens. New balance {} — Total funds: {}",
@@ -133,7 +133,7 @@ impl ConditionalEscrow {
 
         Promise::new(payee.clone()).transfer(payment);
         self.deposits.insert(&payee, &0);
-        self.total_funds -= payment;
+        self.total_funds = self.total_funds.wrapping_sub(payment);
 
         log!(
             "{} withdrawn {} NEAR tokens. New balance {} — Total funds: {}",

--- a/rust-escrow/conditional-escrow/src/lib.rs
+++ b/rust-escrow/conditional-escrow/src/lib.rs
@@ -235,7 +235,10 @@ mod tests {
 
         let contract = setup_contract(expires_at, MIN_FUNDING_AMOUNT);
 
-        assert_eq!(0, contract.get_total_funds(), "Total funds should be 0");
+        assert_eq!(0,
+            contract.get_total_funds(),
+            "Total funds should be 0"
+        );
     }
 
     #[test]
@@ -306,7 +309,11 @@ mod tests {
             "Withdrawal should be allowed"
         );
 
-        assert_eq!(0, contract.get_total_funds(), "Total funds should be 0");
+        assert_eq!(
+            0,
+            contract.get_total_funds(),
+            "Total funds should be 0"
+        );
     }
 
     #[test]
@@ -471,7 +478,11 @@ mod tests {
 
         contract.delegate_funds();
 
-        assert_eq!(0, contract.get_total_funds(), "Total funds should be 0");
+        assert_eq!(
+            0,
+            contract.get_total_funds(),
+            "Total funds should be 0"
+        );
 
         assert_eq!(
             MIN_FUNDING_AMOUNT,


### PR DESCRIPTION
Improve the way the adds and subtractions are doing to avoid overflow the **_total_funds_** var. 

- https://doc.rust-lang.org/std/primitive.u128.html#method.wrapping_add
- https://doc.rust-lang.org/std/primitive.u128.html#method.wrapping_sub